### PR TITLE
Dashboard can give data for specific accounts instead of all

### DIFF
--- a/Application/feed-them-money/src/app/api/dashboard/route.js
+++ b/Application/feed-them-money/src/app/api/dashboard/route.js
@@ -1,6 +1,13 @@
 import { query } from "@/lib/db";
 
-export async function GET() {
-  const data = await query(`SELECT * FROM FullDashboard`);
-  return Response.json(data);
+export async function POST(request) {
+    const { money_account } = await request.json();
+    let localMoneyAccount=0
+    if (money_account) {
+      localMoneyAccount=money_account
+    }
+    // 456
+    const data = await query(`CALL fetch_month_dashboard(?)`, [localMoneyAccount]);
+    const result = data[0]; // First result set
+    return Response.json(result);
 }

--- a/Application/feed-them-money/src/app/api/fetch_category_details/route.js
+++ b/Application/feed-them-money/src/app/api/fetch_category_details/route.js
@@ -1,10 +1,12 @@
 import { query } from "@/lib/db";
 
 export async function POST(request) {
-    const { month, category } = await request.json();
+    const { month, category, money_account } = await request.json();
+    const localMoneyAccount= money_account || 0;
     if (!month || !category) {
         return Response.json({ error: "Month and category are required" }, { status: 400 });
     }
-    const data = await query(`SELECT DATE(txn_date) AS txn_date, particulars, amount FROM ViewTransactions WHERE MONTH(txn_date)=? AND category=? ORDER BY txn_date, txn_id`, [month, category]);
-    return Response.json(data);
+    const data = await query(`CALL fetch_transactions(?,?,?)`, [month, category, localMoneyAccount]);
+    const result = data[0]; // First result set
+    return Response.json(result);
 }

--- a/Application/feed-them-money/src/app/app/page.js
+++ b/Application/feed-them-money/src/app/app/page.js
@@ -8,13 +8,19 @@ export default function Home() {
     const [selectedCells, setSelectedCells] = useState([]);
     const [detailMode, setDetailMode] = useState(false);
     const [transactionDetails, setTransactionDetails] = useState([]);
+    const [moneyAccounts, setMoneyAccounts] = useState([]);
+    const [selectedMoneyAccount, setSelectedMoneyAccount] = useState(0);
 
-    useEffect(() => {
-      fetch("/api/dashboard")
-        .then((response) => response.json())
-        .then((data) => setData(data))
+    const fetchDashboard = () => {
+      fetch("/api/dashboard", {method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({money_account: selectedMoneyAccount})}).then((response) => response.json())
+        .then((data) => {
+          console.log("Dashboard Data:", data);
+          setData(data)
+        })
         .catch((error) => console.error("Error fetching transactions:", error));
-  
+    }
+
+    const fetchOpeningBalances = () => {
       fetch("/api/settings/load_opening_balance")
         .then((response) => response.json())
         .then((balances) => {
@@ -26,6 +32,23 @@ export default function Home() {
           setOpeningBalances(ob);
         })
         .catch((error) => console.error("Error fetching opening balances:", error));
+    };
+
+    const fetchMoneyAccounts = () => {
+      fetch("/api/transactions/load_money_accounts")
+          .then((response) => response.json()) 
+          .then((accounts) => {
+            setMoneyAccounts(accounts);
+          })
+          .catch((error) => console.error("Error fetching money accounts:", error));
+    }
+
+    useEffect(() => {fetchDashboard();}, [selectedMoneyAccount]); 
+
+    useEffect(() => {  
+      fetchDashboard();
+      fetchOpeningBalances();
+      fetchMoneyAccounts();
     }, []);
 
     const handleSpentCellClick = (cellKey, amount) => {
@@ -60,7 +83,7 @@ export default function Home() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ month, category }),
+        body: JSON.stringify({ month, category, money_account: selectedMoneyAccount}),
       })  
       .then(response => response.json())
       .then(data => {
@@ -100,6 +123,21 @@ export default function Home() {
                   </div>
                   <span className="text-xs font-semibold">Detail Mode</span>
                 </label>
+                <div className="ml-6">
+                  <label className="text-xs font-semibold mr-2">Money Account:</label>
+                  <select
+                    value={selectedMoneyAccount}
+                    onChange={(e) => setSelectedMoneyAccount(Number(e.target.value))}
+                    className="border p-1 rounded"
+                  >
+                    <option value={0}>All Accounts</option>
+                    {moneyAccounts.map((account) => (
+                      <option key={account.id} value={account.id}>
+                        {account.account_name}
+                      </option>
+                    ))}
+                  </select>
+                </div>
             </div>
             <div className="overflow-x-auto">
             {data.length === 0 ? (


### PR DESCRIPTION
A money account dropdown has been added to the dashboard where the user can choose a account for which the details need to be seen.

When the user clicks on the detail mode, the money account filter gets applied there as well.